### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+* Updated files to work with latest CI updates
+
 # 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -22,7 +22,7 @@ class BaseAction(Action):
 
     def _api_get(self, endpoint, headers={}, params=None):
         _url = self._api_root + endpoint
-        _headers = self._headers.update(headers)
+        _headers = {**self._headers, **headers}
 
         r = requests.get(url=_url, auth=(self._email, self._token),
                          params=params, headers=_headers)
@@ -36,7 +36,7 @@ class BaseAction(Action):
 
     def _api_post(self, endpoint, headers={}, data=None, json=None):
         _url = self._api_root + endpoint
-        _headers = self._headers.update(headers)
+        _headers = {**self._headers, **headers}
 
         r = requests.post(url=_url, auth=(self._email, self._token),
                           data=data, headers=_headers, json=json)
@@ -50,7 +50,7 @@ class BaseAction(Action):
 
     def _api_put(self, endpoint, headers={}, data=None, json=None):
         _url = self._api_root + endpoint
-        _headers = self._headers.update(headers)
+        _headers = {**self._headers, **headers}
 
         r = requests.put(url=_url, auth=(self._email, self._token),
                          data=data, headers=_headers, json=json)
@@ -68,3 +68,7 @@ class BaseAction(Action):
             return None
 
         return slug_name.lower().replace(' ', '-')
+
+    # Not used in actions but needed for testing
+    def run(self, **kwargs):
+        raise RuntimeError("run() not implemented")

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - customer support
   - chat
   - CRM
-version: 1.0.0
+version: 1.0.1
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/tests/test_action_lib_actions.py
+++ b/tests/test_action_lib_actions.py
@@ -1,0 +1,149 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from lib.actions import BaseAction
+
+
+class TestBaseAction(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            'email': 'test@example.com',
+            'api_token': 'test_token',
+            'brand': 'test_brand'
+        }
+        self.action = BaseAction(self.config)
+
+    def test_init(self):
+        self.assertEqual(self.action._email, 'test@example.com')
+        self.assertEqual(self.action._token, 'test_token')
+        self.assertEqual(self.action._brand, 'test_brand')
+        self.assertEqual(self.action._api_root, 'https://test_brand.reamaze.com/api/v1')
+
+    def test_missing_email(self):
+        self.config.pop('email')
+        with self.assertRaises(ValueError) as context:
+            BaseAction(self.config)
+        self.assertEqual(str(context.exception), 'Missing "email" config option')
+
+    def test_missing_brand(self):
+        self.config.pop('brand')
+        with self.assertRaises(ValueError) as context:
+            BaseAction(self.config)
+        self.assertEqual(str(context.exception), 'Missing "brand" config option')
+
+    def test_missing_token(self):
+        self.config.pop('api_token')
+        with self.assertRaises(ValueError) as context:
+            BaseAction(self.config)
+        self.assertEqual(str(context.exception), 'Missing "api_token" config option')
+
+    @patch('lib.actions.requests.get')
+    def test_api_get(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'key': 'value'}
+        mock_get.return_value = mock_response
+
+        response = self.action._api_get('/test_endpoint')
+
+        self.assertEqual(response, {'key': 'value'})
+        mock_get.assert_called_once_with(
+            url='https://test_brand.reamaze.com/api/v1/test_endpoint',
+            auth=('test@example.com', 'test_token'),
+            params=None,
+            headers={'Accept': 'application/json'}
+        )
+
+    @patch('lib.actions.requests.get')
+    def test_api_get_logs_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = '{"error": "not found"}'
+        mock_get.return_value = mock_response
+
+        self.action.logger = MagicMock()
+        self.action._api_get('/test_endpoint')
+
+        self.action.logger.error.assert_called_once_with(
+            'GET failed. HTTP status: %s, Body: %s.',
+            404, '{"error": "not found"}'
+        )
+
+    @patch('lib.actions.requests.post')
+    def test_api_post(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {'key': 'value'}
+        mock_post.return_value = mock_response
+
+        response = self.action._api_post('/test_endpoint', json={'data': 'value'})
+
+        self.assertEqual(response, {'key': 'value'})
+        mock_post.assert_called_once_with(
+            url='https://test_brand.reamaze.com/api/v1/test_endpoint',
+            auth=('test@example.com', 'test_token'),
+            data=None,
+            headers={'Accept': 'application/json'},
+            json={'data': 'value'}
+        )
+
+    @patch('lib.actions.requests.post')
+    def test_api_post_logs_error(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error": "bad request"}'
+        mock_post.return_value = mock_response
+
+        self.action.logger = MagicMock()
+        self.action._api_post('/test_endpoint', json={'data': 'value'})
+
+        self.action.logger.error.assert_called_once_with(
+            'POST failed. HTTP status: %s, Body: %s.',
+            400, '{"error": "bad request"}'
+        )
+
+    @patch('lib.actions.requests.put')
+    def test_api_put(self, mock_put):
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.json.return_value = {'key': 'value'}
+        mock_put.return_value = mock_response
+
+        response = self.action._api_put('/test_endpoint', json={'data': 'value'})
+
+        self.assertEqual(response, {'key': 'value'})
+        mock_put.assert_called_once_with(
+            url='https://test_brand.reamaze.com/api/v1/test_endpoint',
+            auth=('test@example.com', 'test_token'),
+            data=None,
+            headers={'Accept': 'application/json'},
+            json={'data': 'value'}
+        )
+
+    @patch('lib.actions.requests.put')
+    def test_api_put_logs_error(self, mock_put):
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = '{"error": "bad request"}'
+        mock_put.return_value = mock_response
+
+        self.action.logger = MagicMock()
+        self.action._api_put('/test_endpoint', json={'data': 'value'})
+
+        self.action.logger.error.assert_called_once_with(
+            'PUT failed. HTTP status: %s, Body: %s.',
+            400, '{"error": "bad request"}'
+        )
+
+    def test_convert_slug(self):
+        self.assertEqual(self.action._convert_slug('Test Slug'), 'test-slug')
+        self.assertEqual(self.action._convert_slug('Another Test'), 'another-test')
+        self.assertIsNone(self.action._convert_slug(None))
+
+    def test_run(self):
+        with self.assertRaises(RuntimeError):
+            self.action.run()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- fixing lint error: `Assigning result of a function call, where the function has no return` by combining header dicts instead of updating `self._headers`
    - I don't know if this was ever working as expected because update returns `None` to `_headers` which was then passed into the `requests.get` function instead of the updated `self._headers`
- Added unit tests for lib/actions.py because the build fails if there aren't any tests to run